### PR TITLE
Config option 'interval' is ignored

### DIFF
--- a/Ext.ux.ActivityMonitor.js
+++ b/Ext.ux.ActivityMonitor.js
@@ -27,7 +27,7 @@ Ext.define('Ext.ux.ActivityMonitor', {
             ui         : Ext.getBody(),
             task       : {
                 run      : this.monitorUI,
-                interval : this.interval,
+                interval : config.interval || this.interval,
                 scope    : this
             }
         });


### PR DESCRIPTION
The taskRunner was pulling the interval from the this.interval before the user provided config was applied.  Changed to take from config.interval and fallback to this.interval
